### PR TITLE
fixes counts in hover

### DIFF
--- a/src/components/EditorStatusBar/EditorStatusBar.js
+++ b/src/components/EditorStatusBar/EditorStatusBar.js
@@ -82,13 +82,13 @@ const EditorStatusBar = ({
         <Spacer size={UNIT * 2} />
         <CountIndicator
           num={numOfMines}
-          label={pluralize(numOfBlocks, 'mine')}
+          label={pluralize(numOfMines, 'mine')}
           icon={globe}
         />
         <Spacer size={UNIT * 2} />
         <CountIndicator
           num={numOfObstacles}
-          label={pluralize(numOfBlocks, 'obstacle')}
+          label={pluralize(numOfObstacles, 'obstacle')}
           icon={codepen}
         />
         <Spacer size={UNIT * 6} />


### PR DESCRIPTION
Hello! 

I noticed this small bug in the tooltips in the status bar. 

### Before
<img width="221" alt="Screen Shot 2019-09-18 at 6 27 33 PM" src="https://user-images.githubusercontent.com/1787498/65193075-c9854b80-da47-11e9-9305-7acff5674cd4.png">

### After
<img width="249" alt="Screen Shot 2019-09-18 at 6 27 14 PM" src="https://user-images.githubusercontent.com/1787498/65193090-d73ad100-da47-11e9-9498-ebb699a81da1.png">
