### PR TITLE
Fix: playbackRate effect on timings

### DIFF
--- a/src/services/audio.service.js
+++ b/src/services/audio.service.js
@@ -17,6 +17,9 @@ class AudioSample {
     // we'll store the currentTime position that the audio started playing.
     this.startTime = null;
 
+    // If playback rate changes, we need track when for computation
+    this.playbackRateLastSetAt = null;
+
     // When we pause the song, we might be 55 seconds into its playback.
     // Store the number 55, so that we know where to resume from.
     // This is because there is no native "pause" functionality.
@@ -35,6 +38,17 @@ class AudioSample {
   }
 
   changePlaybackRate(playbackRate) {
+    // Every time that the playback rate changes,
+    // we first need to calculate how much elapsed with the old rate,
+    // offset the start time to compensate, and then start a new segment
+    const rateAdjustedElapsed = this.getRateAdjustedElapsed();
+    const realElapsed = this.context.currentTime - this.playbackRateLastSetAt;
+
+    // We have to shift the playback head pointer backwards or forwards,
+    // to make up for changes in playback rate
+    this.startTime = this.startTime + realElapsed - rateAdjustedElapsed;
+
+    this.playbackRateLastSetAt = this.context.currentTime;
     this.playbackRate = playbackRate;
 
     // Audio source might not yet be loaded
@@ -62,6 +76,7 @@ class AudioSample {
   play() {
     // Keep track of when we started playing.
     this.startTime = this.context.currentTime - this.startOffset;
+    this.playbackRateLastSetAt = this.context.currentTime;
     this.isPlaying = true;
 
     this.source = this.context.createBufferSource();
@@ -88,7 +103,17 @@ class AudioSample {
   }
 
   getCurrentTime() {
-    return this.context.currentTime - this.startTime;
+    return (
+      this.getRateAdjustedElapsed() +
+      (this.playbackRateLastSetAt - this.startTime)
+    );
+  }
+
+  getRateAdjustedElapsed() {
+    return (
+      (this.context.currentTime - this.playbackRateLastSetAt) *
+      this.playbackRate
+    );
   }
 
   setCurrentTime(time) {

--- a/src/services/audio.service.js
+++ b/src/services/audio.service.js
@@ -36,7 +36,11 @@ class AudioSample {
 
   changePlaybackRate(playbackRate) {
     this.playbackRate = playbackRate;
-    this.source.playbackRate.value = this.playbackRate;
+
+    // Audio source might not yet be loaded
+    if (this.source) {
+      this.source.playbackRate.value = this.playbackRate;
+    }
   }
 
   load(arrayBuffer) {


### PR DESCRIPTION
Hi Joshua,

First, I just want to say thank you for all your hard work on this. This is seriously one of the most impressive web apps that I've ever seen, and I am constantly impressed by how much more intuitive and easy-to-use Beatmapper is in comparison with other map editor software. It is a pleasure to use, especially for novices like myself who are looking to create their first maps. I honestly can't say enough nice things about this app.

---

As for this PR, it should address multiple issues with the "playback rate" feature / slider (#91 & #94). 

The main issue seemed to be that the `AudioSample` class method of `getCurrentTime()` was returning the difference between the context current time (i.e. "now") and the sample start time, regardless of playbackRate. An easy fix would be to multiply this by the `playbackRate` (such as suggested [here](https://stackoverflow.com/questions/31644060/how-can-i-get-an-audiobuffersourcenodes-current-time#comment91354397_31653217)), but this makes a faulty assumption that the playbackRate has not changed throughout the song.

My final fix was to basically to:
 - Listen whenever the playback rate changes, and then:
     - Compute the previous "rate-adjusted" elapsed time, and move the play head (startTime) to accommodate for the difference between "real world" time elapsed and "rate-adjusted" time elapsed
     - Store the time at which the playbackRate was changed, to be used for future computations
 - For `getCurrentTime()`, compute the "rate-adjusted" amount for the current segment, and add it to the *already* rate-adjusted (via startTime offset) previous segment

This is not the only way this could have been done. If you would prefer a different approach, please let me know, and I can do my best to rewrite my solution.

---

This PR also fixes a very small bug related to playbackRate, called out in [this comment](https://github.com/joshwcomeau/beatmapper/issues/91#issuecomment-599344846). Basically, a fatal error is triggered if you try to change playbackRate before the song has loaded into memory.

---

Finally, as for tests, I started going down the path of adding a test to cover playbackRate timing computation, but immediately realized I was going to have issues with Jest, due to the lack of a mocked Web Audio API. If you really want tests added for this,  I could look into either adding a Audio API mocking library to dependencies, or having tests run in a full browser, with something  like Playwright or Puppeteer.

---
Thanks again for all your hard work on this! Please let me know if you have any feedback, required changes, etc.