### PR TITLE
Info.dat support

### DIFF
--- a/src/middlewares/packaging.middleware.js
+++ b/src/middlewares/packaging.middleware.js
@@ -48,7 +48,7 @@ export default function createPackagingMiddleware() {
     // in this case.
     if (selectedSong) {
       const difficulty = getDifficulty(state);
-      // Persist the info.dat and the currently-edited difficulty.
+      // Persist the Info.dat and the currently-edited difficulty.
       await saveInfoDat(song.id, infoContent);
       await saveBeatmap(song.id, difficulty, beatmapContent);
 

--- a/src/middlewares/song.middleware.js
+++ b/src/middlewares/song.middleware.js
@@ -230,7 +230,7 @@ export default function createSongMiddleware() {
         // in the song reducer
         next(action);
 
-        // Pull that updated redux state and save it to our info.dat
+        // Pull that updated redux state and save it to our Info.dat
         const state = store.getState();
         const song = getSongById(state, songId);
 

--- a/src/services/file.service.ts
+++ b/src/services/file.service.ts
@@ -94,7 +94,7 @@ export const getFilenameForThing = (
     }
 
     case 'info': {
-      return `${songId}_info.dat`;
+      return `${songId}_Info.dat`;
     }
 
     case 'beatmap': {
@@ -137,7 +137,7 @@ export const getBeatmap = (
     } else {
       throw new Error(
         'Expected beatmapFilename to load a string, loaded: ' +
-          typeof beatmapContents
+        typeof beatmapContents
       );
     }
   });
@@ -241,7 +241,7 @@ export const deleteAllSongFiles = async (song: any) => {
    *   - Song file (.ogg)
    *   - Cover art
    *   - All difficulty beatmaps
-   *   - info.dat
+   *   - Info.dat
    */
   const { id, songFilename, coverArtFilename, difficultiesById } = song;
 

--- a/src/services/packaging.service.js
+++ b/src/services/packaging.service.js
@@ -346,7 +346,7 @@ export const zipFiles = (song, songFile, coverArtFile, version) => {
     if (version === 2) {
       zip.file('song.egg', songFile, { binary: true });
       zip.file('cover.jpg', coverArtFile, { binary: true });
-      zip.file('info.dat', infoContent, { binary: false });
+      zip.file('Info.dat', infoContent, { binary: false });
     } else {
       zip.file('song.ogg', songFile, { binary: true });
       zip.file('cover.jpg', coverArtFile, { binary: true });
@@ -406,7 +406,7 @@ export const zipFiles = (song, songFile, coverArtFile, version) => {
       zip.file(LIGHTSHOW_FILENAME, lightshowFileContents, { binary: false });
     }
 
-    zip.generateAsync({ type: 'blob' }).then(function(blob) {
+    zip.generateAsync({ type: 'blob' }).then(function (blob) {
       const timestamp = formatDate(new Date(), 'YYYYMMDDTHHmm');
       const filename =
         version === 1
@@ -479,7 +479,7 @@ export const convertLegacyArchive = async archive => {
     })
   );
 
-  // Finally, create our new info.dat, and zip it up.
+  // Finally, create our new Info.dat, and zip it up.
   const difficultiesById = loadedDifficultyFiles.reduce((acc, level) => {
     return {
       ...acc,
@@ -500,7 +500,7 @@ export const convertLegacyArchive = async archive => {
   };
 
   const newInfoContent = createInfoContent(fakeSong, { version: 2 });
-  zip.file('info.dat', newInfoContent, { binary: false });
+  zip.file('Info.dat', newInfoContent, { binary: false });
 
   return zip;
 };
@@ -516,8 +516,8 @@ export const processImportedMap = async (zipFile, currentSongIds) => {
   }
 
   // Zipped contents are always treated as binary. We need to convert the
-  // info.dat into something readable
-  const infoDatString = await getFileFromArchive(archive, 'info.dat').async(
+  // Info.dat into something readable
+  const infoDatString = await getFileFromArchive(archive, 'Info.dat').async(
     'string'
   );
   const infoDatJson = JSON.parse(infoDatString);
@@ -534,7 +534,7 @@ export const processImportedMap = async (zipFile, currentSongIds) => {
     }
   }
 
-  // Save the info.dat (Not 100% sure that this is necessary, but better to
+  // Save the Info.dat (Not 100% sure that this is necessary, but better to
   // have and not need)
   const infoFilename = getFilenameForThing(songId, 'info');
   await saveFile(infoFilename, infoDatString);
@@ -629,7 +629,7 @@ export const processImportedMap = async (zipFile, currentSongIds) => {
     realOffset =
       infoDatJson._difficultyBeatmapSets[0]._difficultyBeatmaps[0]._customData
         ._editorOffset || 0;
-  } catch (e) {}
+  } catch (e) { }
 
   const wasCreatedInBeatmapper =
     get(infoDatJson, '_customData._editor') === 'beatmapper';

--- a/src/services/packaging.service.nitty-gritty.js
+++ b/src/services/packaging.service.nitty-gritty.js
@@ -9,7 +9,7 @@ export const getFileFromArchive = (archive, filename) => {
 
   const allFilenamesInArchive = Object.keys(archive.files);
   const matchingFilename = allFilenamesInArchive.find(name =>
-    name.includes(filename)
+    name.toLowerCase().includes(filename.toLowerCase())
   );
 
   return archive.files[matchingFilename];
@@ -30,9 +30,9 @@ export const getDifficultyRankForDifficulty = difficulty => {
 export const getArchiveVersion = archive => {
   // We could be importing a v1 or v2 song, we don't know which.
   // For now, I'm going to do the very lazy thing of just assuming based on
-  // the file type; v1 has `info.json` while v2 has `info.dat`
+  // the file type; v1 has `info.json` while v2 has `Info.dat`
   // TODO: More reliable version checking
-  return getFileFromArchive(archive, 'info.dat') ? 2 : 1;
+  return getFileFromArchive(archive, 'Info.dat') ? 2 : 1;
 };
 
 const shiftEntitiesByOffsetInBeats = (entities, offsetInBeats) => {

--- a/src/workers/autosave.worker.js
+++ b/src/workers/autosave.worker.js
@@ -8,7 +8,7 @@ import { getDifficulty } from '../reducers/editor-entities.reducer';
 //
 // The only Redux state persisted is the `songs` reducer; for stuff like
 // what the notes are for the current song, we'll read that from the files
-// saved to disk, stuff like `songName_info.dat` and `songName_Expert.dat`.
+// saved to disk, stuff like `songName_Info.dat` and `songName_Expert.dat`.
 //
 // Whenever redux saves the song list, we should also save all the stuff
 // in the editor-entities reducer by storing them in info files.


### PR DESCRIPTION
Fixes #96 

Relatively recently, it was decided that beatsaver would be switching to using `Info.dat` rather than `info.dat`, and while lowercased files are still supported for some time yet, it will eventually be forcing a capital I.

This PR is mainly just to prepare for that change by preemptively switching to export as capital I, and adds support for importing a zip with such a filename as well. I did change what I believe to be the internal filename for the song's info.dat as well, however with some basic testing (import some maps with one name, change the capitalization, rebuild, maps are still there and functional) this does not seem to be a functional change, just one for consistency. If this is in fact not the case, it can be easily reverted to maintain the internal filestate.