### PR TITLE
Copy-paste fix in events manual

### DIFF
--- a/src/docs/manual/events-view.mdx
+++ b/src/docs/manual/events-view.mdx
@@ -246,13 +246,13 @@ You can toggle between Add and Select mode through the "Edit Mode" control, or t
 
 Armed with the Select mode box tool, we can quickly select groups of events. Let's look at how we can use selections to our advantage.
 
-Sometimes we simply want to erase a section. We can do this by pressing `Delete` - all selected notes will be removed.
+Sometimes we simply want to erase a section. We can do this by pressing `Delete` - all selected events will be removed.
 
 We can also cut, copy, and paste selections using the typical shortcuts. This is an effective way to move groups of events around (cut -> paste), or repeat a set of events (copy -> paste).
 
 > Pasting is based on the mouse's cursor position, the thin white line, and _not_ the thick yellow line indicating the song's position. This gives you much greater control to quickly paste repeated sections.
 
-If you want to un-select all events, you can press the `Escape` key. You can also select all _visible_ notes by using `ctrl+A` or `⌘+A`.
+If you want to un-select all events, you can press the `Escape` key. You can also select all _visible_ events by using `ctrl+A` or `⌘+A`.
 
 > Note that the "Select all" shortcut is slightly different from the Notes view; in Notes, "Select all" selects all entities across the entire map, whilst in the Events view, it only selects events within the current window, visible on-screen.
 


### PR DESCRIPTION
These lines are referring to selected events, not notes.